### PR TITLE
Fixed minor errors in the JavaScript for the push tutorial

### DIFF
--- a/views/docs/push.html.twig
+++ b/views/docs/push.html.twig
@@ -297,7 +297,8 @@ class Pusher implements WampServerInterface {
       , function() {            // Once the connection has been established
             conn.subscribe('kittensCategory', function(topic, data) {
                 // This is where you would add the new article to the DOM (beyond the scope of this tutorial)
-                console.log('New article published to category "' + topic + '" : ' + data.title);
+                var dataObj = JSON.parse(data);
+                console.log('New article published to category "' + topic + '" : ' + dataObj.title);
             });
         }
       , function() {            // When the connection is closed


### PR DESCRIPTION
var conn is the ab.Session object but was being referenced as "sess" inside the onopen callback.
