### PR TITLE
Update install.html.twig

### DIFF
--- a/views/docs/install.html.twig
+++ b/views/docs/install.html.twig
@@ -22,14 +22,10 @@
 
                 <p>
                     The best (and currently only) way to install Ratchet is using <a rel="external" href="http://getcomposer.org">composer</a>.
-                    Simply add Ratchet as a require in your <em>composer.json</em> file:
+                    Simply add Ratchet by running this:
                 </p>
 
-                <pre class="prettprint">{
-    "require": {
-        "cboden/ratchet": "0.3.*"
-    }
-}</pre>
+                <pre class="prettprint">php ~/composer.phar require cboden/ratchet</pre>
             </section>
 
             <hr>


### PR DESCRIPTION
Updated installation instructions via composer to use the `composer require` command without specifying a version.
This is the new recommended way of providing this information and it leads to composer picking the proper version constraint (i.e ~1.2), updating the `composer.json` and running install, all in one command.
