### PR TITLE
fix callError's arguments and callback

### DIFF
--- a/src/Ratchet/Website/Chat/ChatRoom.php
+++ b/src/Ratchet/Website/Chat/ChatRoom.php
@@ -56,7 +56,7 @@ class ChatRoom implements WampServerInterface {
                 $created = false;
 
                 if (empty($topic)) {
-                    return $conn->callError($id, 'Room name can not be empty');
+                    return $conn->callError($id, 'createRoom', 'Room name can not be empty');
                 }
 
                 if (array_key_exists($topic, $this->roomLookup)) {
@@ -74,12 +74,12 @@ class ChatRoom implements WampServerInterface {
 
                     return $conn->callResult($id, array('id' => $roomId, 'display' => $topic));
                 } else {
-                    return $conn->callError($id, array('id' => $roomId, 'display' => $topic));
+                    return $conn->callError($id, 'createRoom', "Room '{$topic}' exists", array('id' => $roomId, 'display' => $topic));
                 }
             break;
 
             default:
-                return $conn->callError($id, 'Unknown call');
+                return $conn->callError($id, '', 'Unknown call');
             break;
         }
     }

--- a/web/chat/transport.js
+++ b/web/chat/transport.js
@@ -113,7 +113,7 @@ ChatRoom = function(optDebug) {
             sess.call('createRoom', name).then(function(args) {
                 callback(args.id, args.display);
             }, function(args) {
-                callback(args.id, args.display);
+                callback(args.detail.id, args.detail.display);
             });
         }
 


### PR DESCRIPTION
`callError` method has different arguments to `callResult`
