### PR TITLE
supervisor process tweak so process is stoppable

### DIFF
--- a/views/docs/deploy.html.twig
+++ b/views/docs/deploy.html.twig
@@ -177,7 +177,7 @@ supervisor.rpcinterface_factory = supervisor.rpcinterface:make_main_rpcinterface
 serverurl = unix:///tmp/supervisor.sock
 
 [program:ratchet]
-command                 = bash -c "ulimit -n 10000 && /usr/bin/php ./bin/tutorial-terminal-chat.php"
+command                 = bash -c "ulimit -n 10000; exec /usr/bin/php ./bin/tutorial-terminal-chat.php"
 process_name            = Ratchet
 numprocs                = 1
 autostart               = true


### PR DESCRIPTION
Don't know exacly whats going on but while enhancing your chat example so it would actually halt (via SIGTERM signal, from supervisor) I noticed that the php process was't killed at all (resulting in a port in use error on the next start). The 'SIGTERM' signal never reached PHP.

After googling and fiddling a bit this seems to be a better way. the signal arrives in PHP and the process is halted. and the ulimit seems to be in effect (tested by using 1)