### PR TITLE
Documentation fixes

### DIFF
--- a/views/docs/black.html.twig
+++ b/views/docs/black.html.twig
@@ -43,7 +43,7 @@
 
                 <ul>
                     <li>IpBlackList <strong>blockAddress</strong> (string $address) - Specify an address to be blocked.  This can be an IP4, IP6, or named address</li>
-                    <li>IpBlackList <strong>unblockAddress</strong> (string $address) - Unblock and address that was previously blocked</li>
+                    <li>IpBlackList <strong>unblockAddress</strong> (string $address) - Unblock an address that was previously blocked</li>
                     <li>boolean <strong>isBlocked</strong> (string $address) - Check to see if an address is being blocked</li>
                     <li>array <strong>getBlockedAddresses</strong> () - Return an indexed array of all the addresses being blocked</li>
                 </ul>

--- a/views/docs/deploy.html.twig
+++ b/views/docs/deploy.html.twig
@@ -15,13 +15,13 @@
     {{ m.menu() }}
 
       <div class="span9">
-            <h2>Deployment <small>- shippit!</small></h2>
+            <h2>Deployment <small>- ship it!</small></h2>
 
             <section><p>
                 You've built your application and are ready to deploy it live!
                 This tutorial will give you recommendations on what you should do to setup your production environment to run a WebSocket server. 
                 None of these are required, but recommended. 
-                Please note this page serves as an introduction and boilerplate setup for each technoloogy; each topic has wealths of more detailed resources available. 
+                Please note this page serves as an introduction and boilerplate setup for each technology; each topic has many more detailed resources available. 
             </p></section>
 
             <section id="ulimit">
@@ -30,8 +30,8 @@
                 <p>
                     A Unix philosophy is "everything is a file". This means each user connecting to your WebSocket application is represented <em>as</em> a file somewhere. 
                     A security feature of every Unix based OS is to limit the number of file descriptors one running application may have open at a time. 
-                    On many systems this default is 1024. 
-                    This would mean if you had 1024 users currently connected to your WebSocket server anyone else attempting to connect would fail to do so. 
+                    On many systems this default is 1,024. 
+                    This would mean if you had 1,024 users currently connected to your WebSocket server anyone else attempting to connect would fail to do so. 
                 </p>
                 
                 <p>
@@ -72,9 +72,8 @@
                 <p>Disable the XDebug extension.  Make sure it is commented out of your php.ini file.  XDebug is fantastic for development, but destroys performance in production.</p>
             </section>
 
-            <a name="sconf"></a>
-            <section id="serverconfiguration">
-                <h3>Server Configuration <a class="headerlink" href="#serverconfiguration" title="Permalink to this headline">¶</a></h3>
+            <section id="server_configuration">
+                <h3>Server Configuration <a class="headerlink" href="#server_configuration" title="Permalink to this headline">¶</a></h3>
 
                 <p>There's a couple things you need to know when deploying a WebSocket server that impact how you set up your server architecture:</p>
                 <ul>
@@ -84,16 +83,16 @@
 
                 <p>Given these issues with WebSockets we have three choices on how to architect:</p>
                 <ul>
-                    <li>Run your website and WebSocket server on the same machine using port 8080 for WebSockets and take the chance client proxies won't block traffic</li>
+                    <li>Run your web site and WebSocket server on the same machine using port 8080 for WebSockets and take the chance client proxies won't block traffic</li>
                     <li>Run your WebSocket server on its own server on port 80 under a subdomain (sock.example.com)</li>
-                    <li>Put a reverse proxy (HAProxy or Varnish) in front of your webserver and WebSocket server</li>
+                    <li>Put a reverse proxy (HAProxy or Varnish) in front of your web server and WebSocket server</li>
                 </ul>
 
                 <p>
                     The first two options are fairly easy with the second being a decent option if you can afford a second server.
                     This article will detail the third option and show you how to configure your network, specifically HAProxy, to run your web and WebSocket servers on the same machine. 
                     We've chosen to demonstrate HAProxy because it can also handle SSL (in v1.5) where Varnish can not. 
-                    The goal is to setup the architecutre like the diagram below.
+                    The goal is to setup the architecture like the diagram below.
                 </p>
 
                 <p><img src="/assets/img/proxy-arch.png"></p>
@@ -154,8 +153,8 @@ backend www
                 <h3>Supervisor <a class="headerlink" href="#supervisor" title="Permalink to this headline">¶</a></h3>
 
                 <p>
-                    When running Ratchet in production it's highly recommended launching it from <a href="http://supervisord.org" target="_blank" rel="external">suporvisord</a>.
-                    Suporvisor is a daemon that launches other processes and ensures they stay running.  
+                    When running Ratchet in production it's highly recommended launching it from <a href="http://supervisord.org" target="_blank" rel="external">supervisord</a>.
+                    Supervisor is a daemon that launches other processes and ensures they stay running.  
                     If for any reason your long running Ratchet application halted the supervisor daemon would ensure it starts back up immediately.
                     Supervisor can be installed with any of the following tools: pip, easy_install, apt-get, yum. 
                     Once supervisor is installed you generate a template file with the following command:
@@ -206,8 +205,8 @@ stderr_logfile_maxbytes = 1MB</pre></p>
 	           <h3>Links</h3>
 
 	           <ul>
-	               <li><a href="http://libevent.org" rel="external">LibEvent</a></li>
-	               <li><a href="http://pecl.php.net/package/libevent" rel="external">Libevent PHP extension</a></li>
+	               <li><a href="http://libevent.org" rel="external">libevent</a></li>
+	               <li><a href="http://pecl.php.net/package/libevent" rel="external">libevent PHP extension</a></li>
 	               <li><a href="http://haproxy.1wt.eu/download/1.5/doc/configuration.txt" rel="external">HAProxy Configuration Manual v1.5</a></li>
 	               <li><a href="http://supervisord.org/configuration.html" rel="external">Supervisor Configuration</a></li>
 	           </ul>

--- a/views/docs/flow.html.twig
+++ b/views/docs/flow.html.twig
@@ -2,7 +2,7 @@
 
 {% import "macros.html.twig" as m %}
 
-{% block title %}A WebSocket's Lifecycle on your Website{% endblock %}
+{% block title %}A WebSocket's Lifecycle on your Web Site{% endblock %}
 
 {% block description %}
   Long running, open ended connections work differently than Apache/Nginx CGI you may be used to
@@ -31,15 +31,15 @@
                 </p>
             </section>
 
-            <section id="executionorder">
-                <h3>Execution Order <a class="headerlink" href="#executionorder" title="Permalink to this headline">¶</a></h3>
+            <section id="execution_order">
+                <h3>Execution Order <a class="headerlink" href="#execution_order" title="Permalink to this headline">¶</a></h3>
 
                 <p>Below, the diagram illustrates the order of execution beginning with a client requesting a web page on your site:</p>
 
                 <p><img src="/assets/img/RatchetFlow.png" alt="Network architecture timeline"></p>
 
                 <p>
-                    As you can see, once the webpage has been loaded a WebSocket connection is made back to your Ratchet application, where if everything goes correctly, a connection remains open where either the server or client can send data to the other one at any given time.
+                    As you can see, once the web page has been loaded a WebSocket connection is made back to your Ratchet application, where if everything goes correctly, a connection remains open where either the server or client can send data to the other one at any given time.
                     This has been a network overview of how Ratchet will work.  To understand how your Ratchet application acts, continue on reading <a href="/docs/design">Design Philosophy</a>.
                 </p>
             </section>

--- a/views/docs/hello-universe.html.twig
+++ b/views/docs/hello-universe.html.twig
@@ -49,7 +49,7 @@
               </p>
 
               <p>
-                  We will accomplish this by using the <a href="/docs/wamp">WAMPServerComponent</a> as well as an accompanying Javascript library called <a rel="external" href="http://autobahn.ws/developers/autobahnjs">AutobahnJS</a> (<a rel="external" href="https://github.com/tavendo/AutobahnJS">GitHub Repo</a>).
+                  We will accomplish this by using the <a href="/docs/wamp">WAMPServerComponent</a> as well as an accompanying Javascript library called <a rel="external" href="http://autobahn.ws/developers/autobahnjs">AutobahnJS</a> (<a rel="external" href="https://github.com/tavendo/AutobahnJS">GitHub repo</a>).
                   Knowing we will be using the <em>WAMPComponent</em>, it requires an object that implements the <a href="/api/class-Ratchet.Component.WAMP.WAMPServerComponentInterface.html">WAMPServerComponentInterface</a>, so our class will implement that:
               </p>
 

--- a/views/docs/hello-world.html.twig
+++ b/views/docs/hello-world.html.twig
@@ -27,8 +27,8 @@
                 </p>
             </section>
 
-            <section id="chatclass">
-                <h3>The Chat class <a class="headerlink" href="#chatclass" title="Permalink to this headline">¶</a></h3>
+            <section id="chat_class">
+                <h3>The Chat class <a class="headerlink" href="#chat_class" title="Permalink to this headline">¶</a></h3>
 
                 <p><strong>Note:</strong>
                     This document assumes you are familiar with <a href="https://github.com/php-fig/fig-standards/blob/master/accepted/PSR-0.md" target="_blank" rel="external">PSR-0</a>
@@ -37,7 +37,7 @@
 
                 <p>We're going to hold everything in the <em>MyApp</em> namespace.  Your composer file should look something like this:</p>
 
-                <pre class="prettprint">{
+                <pre class="prettyprint">{
     "autoload": {
         "psr-0": {
             "MyApp": "src"
@@ -189,8 +189,8 @@ class Chat implements MessageComponentInterface {
 }</pre>
         </section>
 
-        <section id="runningit">
-            <h3>Running It <a class="headerlink" href="#runningit" title="Permalink to this headline">¶</a></h3>
+        <section id="running_it">
+            <h3>Running It <a class="headerlink" href="#running_it" title="Permalink to this headline">¶</a></h3>
 
             <p>Complete, let's run it and test it. Open up three terminal windows, typing:</p>
 
@@ -201,11 +201,11 @@ class Chat implements MessageComponentInterface {
             <p>In each of the telnet windows, type a message ("Hello World!") and see it appear in the other!</p>
         </section>
 
-        <section id="nextsteps">
-            <h3>Next Steps <a class="headerlink" href="#nextsteps" title="Permalink to this headline">¶</a></h3>
+        <section id="next_steps">
+            <h3>Next Steps <a class="headerlink" href="#next_steps" title="Permalink to this headline">¶</a></h3>
 
             <p>
-                Now that we have a basic working Chat application, let's make that work in a web browser (Chrome, FireFox, or Safari [for now]).
+                Now that we have a basic working Chat application, let's make that work in a web browser (Chrome, Firefox, or Safari [for now]).
                 First, let's go back to our <em>chat-server.php</em> script.
                 We're going to utilize another component of Ratchet; the <em>WsServer</em> class:
             </p>
@@ -230,7 +230,7 @@ use MyApp\Chat;
     $server->run();
 </pre>
 
-            <p>Run the shell script again, open a couple web browser windows, and open a javascript console or a page with the following javascript:</p>
+            <p>Run the shell script again, open a couple of web browser windows, and open a Javascript console or a page with the following Javascript:</p>
 
             <pre class="prettyprint lang-js">var conn = new WebSocket('ws://localhost:8080');
 conn.onopen = function(e) {

--- a/views/docs/install.html.twig
+++ b/views/docs/install.html.twig
@@ -25,13 +25,13 @@
                     Simply add Ratchet by running this:
                 </p>
 
-                <pre class="prettprint">php ~/composer.phar require cboden/ratchet</pre>
+                <pre class="prettyprint">php ~/composer.phar require cboden/ratchet</pre>
             </section>
 
             <hr>
 
-            <section id="waitwhat">
-                <h3>Wait, What? <a class="headerlink" href="#waitwhat" title="Permalink to this headline">¶</a></h3>
+            <section id="wait_what">
+                <h3>Wait, What? <a class="headerlink" href="#wait_what" title="Permalink to this headline">¶</a></h3>
 
                 <p>
                     Unfamiliar with composer?  Composer for PHP is the greatest thing since sliced bread.

--- a/views/docs/origin.html.twig
+++ b/views/docs/origin.html.twig
@@ -5,7 +5,7 @@
 {% block title %}Component: OriginCheck | CORS {% endblock %}
 
 {% block description %}
-    The OriginCheck component will verify incoming HTTP connections come from domains you have white lsited.
+    The OriginCheck component will verify incoming HTTP connections come from domains you have whitelisted.
 {% endblock %}
 
 {% block body %}
@@ -21,8 +21,8 @@
                 <h3>Purpose <small>of this <em>Component</em></small> <a class="headerlink" href="#purpose" title="Permalink to this headline">¶</a></h3>
 
                 <p>
-                    This component helps secure your server from unwanted websites trying to connect users to your server.
-                    When a WebSocket connection from a browser is created it sends the website URL the user is on in an HTTP header.
+                    This component helps secure your server from unwanted web sites trying to connect users to your server.
+                    When a WebSocket connection from a browser is created it sends the web site URL the user is on in an HTTP header.
                     This component will automatically close connections if the browser is not from the site(s) you're expecting.
                 </p>
 

--- a/views/docs/push.html.twig
+++ b/views/docs/push.html.twig
@@ -5,7 +5,7 @@
 {% block title %}Tutorial: Push on the Web{% endblock %}
 
 {% block description %}
-  Bake WebSockets in without breaking your existing website
+  Bake WebSockets in without breaking your existing web site
 {% endblock %}
 
 {% block body %}
@@ -17,8 +17,8 @@
       <div class="span9">
             <h2>Push to an Existing Site<br /><small>Enhance your existing work without wide-spread changes.</small></h2>
 
-            <section class="intro" id="theproblem">
-                <h3>The Problem <a class="headerlink" href="#theproblem" title="Permalink to this headline">¶</a></h3>
+            <section class="intro" id="the_problem">
+                <h3>The Problem <a class="headerlink" href="#the_problem" title="Permalink to this headline">¶</a></h3>
 
                 <p>
                     The previous tutorials were cool and all, but their focus was creating a long lived application where users interacted with each other entirely over WebSockets with no persistence.
@@ -37,11 +37,11 @@
                     We will add real-time updates to our site without disrupting your code base or affecting its current stability.
                 </p>
 
-                <p>For this tutorial we're going to pretend <small>(reads: boilerplate code missing)</small> you're publishing a blog article on your website and the visitors will see the story pop up as soon as you publish it.</p>
+                <p>For this tutorial we're going to pretend <small>(reads: boilerplate code missing)</small> you're publishing a blog article on your web site and the visitors will see the story pop up as soon as you publish it.</p>
             </section>
 
-            <section class="diagram" id="networkarchitecture">
-                <h3>Network Architecture <a class="headerlink" href="#networkarchitecture" title="Permalink to this headline">¶</a></h3>
+            <section class="diagram" id="network_architecture">
+                <h3>Network Architecture <a class="headerlink" href="#network_architecture" title="Permalink to this headline">¶</a></h3>
 
                 <ol>
                     <li>
@@ -69,13 +69,13 @@
                         <img src="/assets/img/push-4.png" alt="Step 4">
                         <p>
                             The WebSocket stack handles the ZeroMQ message and sends it to the appropriate clients through open WebSocket connections.
-                            The web browsers handle the incoming message and update the webpage with Javascript accordingly.
+                            The web browsers handle the incoming message and update the web page with Javascript accordingly.
                         </p>
                     </li>
                 </ol>
 
                 <p>
-                    This workflow is un-obtrusive and it's easy to introduce into existing websites.
+                    This workflow is unobtrusive and it's easy to introduce into existing web sites.
                     The only changes to the site are adding a bit of ZeroMQ to the server and a Javascript file on the client to handle incoming message from the WebSocket server.
                 </p>
             </section>
@@ -94,7 +94,7 @@
 
                 <p>
                     ZeroMQ is a library (libzmq) you will need to install, as well as a PECL extension for PHP bindings.
-                    Installation is easy and is provided for many operating systems on <a href="http://www.zeromq.org" rel="external">their website</a>.
+                    Installation is easy and is provided for many operating systems on <a href="http://www.zeromq.org" rel="external">their web site</a>.
                 </p>
 
                 <h4>React/ZMQ</h4>
@@ -107,7 +107,7 @@
                     To install, your <em>composer.json</em> file should look like this:
                 </p>
 
-                <pre class="prettprint json javascript">{
+                <pre class="prettyprint json javascript">{
     "autoload": {
         "psr-0": {
             "MyApp": "src"
@@ -161,11 +161,11 @@ class Pusher implements WampServerInterface {
                 </p>
             </section>
 
-            <section id="editblogsubmission">
-                <h3>Editing your blog submission <a class="headerlink" href="#editblogsubmission" title="Permalink to this headline">¶</a></h3>
+            <section id="edit_blog_submission">
+                <h3>Editing your blog submission <a class="headerlink" href="#edit_blog_submission" title="Permalink to this headline">¶</a></h3>
 
                 <p>
-                    Next we're going to add a little ZeroMQ magic into your existing website's code where you handle a new blog post.
+                    Next we're going to add a little ZeroMQ magic into your existing web site's code where you handle a new blog post.
                     The code here may be a little basic and archaic compared to the advanced architecture your actual blog is, sitting on Drupal or WordPress, but we're focusing on the fundamentals.
                 </p>
 
@@ -195,13 +195,13 @@ class Pusher implements WampServerInterface {
                 </p>
             </section>
 
-            <section id="zeromqmessages">
-                <h3>Handling ZeroMQ messages <a class="headerlink" href="#zeromqmessages" title="Permalink to this headline">¶</a></h3>
+            <section id="zeromq_messages">
+                <h3>Handling ZeroMQ messages <a class="headerlink" href="#zeromq_messages" title="Permalink to this headline">¶</a></h3>
 
                 <p>
                     Let's go back to our application stub class.
                     As we left it, it was only handling WebSocket connections.
-                    As you saw in our last code snippit, we opened a connection to localhost on port 5555 that we sent data to.
+                    As you saw in our last code snippet, we opened a connection to localhost on port 5555 that we sent data to.
                     We're going to add handling for that ZeroMQ message as well as re-sending it to our WebSocket clients.
                 </p>
 
@@ -242,8 +242,8 @@ class Pusher implements WampServerInterface {
 </pre>
             </section>
 
-            <section id="tyingittogether">
-                <h3>Tying it all together <small>Creating our executable</small> <a class="headerlink" href="#tyingittogether" title="Permalink to this headline">¶</a></h3>
+            <section id="tying_it_together">
+                <h3>Tying it all together <small>Creating our executable</small> <a class="headerlink" href="#tying_it_together" title="Permalink to this headline">¶</a></h3>
 
                 <p>
                     So far we've covered all the logic of sending, receiving, and handling messages.

--- a/views/docs/sessions.html.twig
+++ b/views/docs/sessions.html.twig
@@ -5,7 +5,7 @@
 {% block title %}Component: Sessions | Symfony love{% endblock %}
 
 {% block description %}
-  Access session data from your website by wrapping Symfony2 HttpFoundation's Session tools
+  Access session data from your web site by wrapping Symfony2 HttpFoundation's Session tools
 {% endblock %}
 
 {% block body %}
@@ -21,7 +21,7 @@
                 <h3>Purpose <small>of this <em>Component</em></small> <a class="headerlink" href="#purpose" title="Permalink to this headline">¶</a></h3>
 
                 <p>
-                    The <em>SessionProvider</em> will attach a <a rel="external" href="http://symfony.com/doc/master/components/http_foundation/sessions.html">Symfony2 Session</a> object to each incoming <em>Connection</em> object that will give you read-only access to the session data from your website.
+                    The <em>SessionProvider</em> will attach a <a rel="external" href="http://symfony.com/doc/master/components/http_foundation/sessions.html">Symfony2 Session</a> object to each incoming <em>Connection</em> object that will give you read-only access to the session data from your web site.
                     The <em>SessionProvider</em> <strong>will not work</strong> with any of the Native* session handlers. It is suggested you use choose one of the following <em>Symfony Custom Save Handlers</em>:
                 </p>
 
@@ -33,18 +33,18 @@
                 </ul>
 
                 <p>
-                    In order to access your session data in Ratchet, you must also use the same Symfony Session Handler on you website.
+                    In order to access your session data in Ratchet, you must also use the same Symfony Session Handler on your web site.
                     Below is a network diagram of how the various connections interact to access data:
                 </p>
 
                 <p><img src="/assets/img/RatchetSessions.png" alt="Session Network Architecture"></p>
 
                 <p>
-                    <strong>Important:</strong> Sessions through WebSockets work as they do through a traditional webserver; a cookie is set and transmitted in each request header.
-                    This means that your website and your WebSocket server both <em>must</em> have access to the cookie.
-                    <br>In order for session data to be shared between your website and your WebSocket server they <em>must</em> be on the same domain.
-                    You can achieve this by either hosting them on the same domain and different ports, such as <em>mydomain.com:80</em> (for website) and <em>mydomain.com:8080</em> (for WebSockets).
-                    If you choose to host the WebSocket server on a sub-domain (<em>websocket.mydomain.com:80</em>) make sure to have your website's php.ini file configured like this:
+                    <strong>Important:</strong> Sessions through WebSockets work as they do through a traditional web server; a cookie is set and transmitted in each request header.
+                    This means that your web site and your WebSocket server both <em>must</em> have access to the cookie.
+                    <br>In order for session data to be shared between your web site and your WebSocket server they <em>must</em> be on the same domain.
+                    You can achieve this by either hosting them on the same domain and different ports, such as <em>mydomain.com:80</em> (for web site) and <em>mydomain.com:8080</em> (for WebSockets).
+                    If you choose to host the WebSocket server on a sub-domain (<em>websocket.mydomain.com:80</em>) make sure to have your web site's php.ini file configured like this:
                 </p>
 
                 <p><pre class="prettyprint">session.cookie_domain = ".mydomain.com"</pre></p>

--- a/views/docs/troubleshooting.html.twig
+++ b/views/docs/troubleshooting.html.twig
@@ -23,7 +23,7 @@
                 <p>
                     <strong>Q:</strong> I followed the <a href="/docs/hello-world">Hello World!</a> tutorial and I got it
                     to work in telnet but couldn't get it working in any of the browsers.
-                    <br><strong>A:</strong> <a href="/docs/hello-world#nextsteps">You missed a step</a>
+                    <br><strong>A:</strong> <a href="/docs/hello-world#next_steps">You missed a step</a>
                 </p>
 
                 <hr>
@@ -39,7 +39,7 @@
                 <p>
                     <strong>Q:</strong> I'm using App and I get 403's when I try to connect.
                     <br><strong>A:</strong> This is actually a security feature!
-                    App, by default, enforces a same origin policy to prevent other websites from connecting to your server.
+                    App, by default, enforces a same origin policy to prevent other web sites from connecting to your server.
                     Either make sure you're opening WebSocket connections in JavaScript from the same URL as your $host in App
                     or to allow another Origin the third parameter of App::route() accepts an array of allowed origins.
                 </p>

--- a/views/docs/wamp.html.twig
+++ b/views/docs/wamp.html.twig
@@ -32,7 +32,7 @@
                     If you choose to build your application on the {{ m.wamp() }} spec (highly recommended) you will need a JavaScript library to implement the client side.
                     <a rel="external" href="http://autobahn.ws/js">AutobahnJS</a> is a client to interact with {{ m.wamp() }} servers and is highly recommended to use with Ratchet.
                     Using AutobahnJS has a requirement of a deferred library.  They recommend using <a rel="external" href="https://github.com/cujojs/when">when</a> or <a rel="external" href="http://api.jquery.com/category/deferred-object/">jQuery's deferred library</a>.
-                    The programming reference for AutobahnJS can be found on <a rel="external" href="http://autobahn.ws/js/reference">Autobahn website</a>.
+                    The programming reference for AutobahnJS can be found on the <a rel="external" href="http://autobahn.ws/js/reference">Autobahn web site</a>.
                 </p>
 
                 <p><strong>Note:</strong> Although the documentation specified to use URI's as Topic context, there is no enforcement on client or server; you can use any string to identify these topics.</p>
@@ -42,12 +42,12 @@
                 <h3>Topics <a class="headerlink" href="#topics" title="Permalink to this headline">¶</a></h3>
 
                 <p>
-                    The WampServer componenet provides a new class that is passed to your application: the <a href="/api/class-Ratchet.Wamp.Topic.html">Topic</a> class.
+                    The WampServer component provides a new class that is passed to your application: the <a href="/api/class-Ratchet.Wamp.Topic.html">Topic</a> class.
                     This is a container that stores all of the <em>Connection</em>s who have subscribed to that topic.
                     It also features some useful methods such as <em>broadcast</em> to send a message to every one of its subscribers.
                 </p>
 
-                <p>When calling <em>Connection</em> methods that require "string $topic" you can pass the <em>Topic</em> class or it's id. </p>
+                <p>When calling <em>Connection</em> methods that require "string $topic" you can pass the <em>Topic</em> class or its id. </p>
 
                 <p>If you are familiar with other forms of messaging, <em>topics</em> are equivalent to channels.</p>
             </section>


### PR DESCRIPTION
- inserted underscores in section ids and permalinks, to avoid the
  crafted ids from being flagged as misspellings
- replaced "prettprint" with "prettyprint" in code block classes
- fixed various typos
- replaced "webpage" with "web page"
- replaced "website" with "web site"
- replaced "wealths of" with "many"
- added commas to numbers that needed them
- removed a seemingly unnecessary named anchor "sconf"
- fixed capitalization for various product names
- applied a couple of minor grammatical fixes