### PR TITLE
Update hello-world: Fix dead link to SPL docs

### DIFF
--- a/views/docs/hello-world.html.twig
+++ b/views/docs/hello-world.html.twig
@@ -138,7 +138,7 @@ use MyApp\Chat;
             <p>
                 Let's add some logic to our <em>Chat</em> class.
                 What we're going to do, is track all incoming <em>Connections</em>, in order to send them messages.
-                Typically, you would store a collection of items in an array, but we're going to use something called <a rel="external" href="http://ca2.php.net/manual/en/class.splobjectstorage.php">SplObjectStorage</a>.
+                Typically, you would store a collection of items in an array, but we're going to use something called <a rel="external" href="https://www.php.net/manual/en/class.splobjectstorage.php">SplObjectStorage</a>.
                 These storage containers are built to store objects, which is what the incoming <em>Connections</em> are.
             </p>
 


### PR DESCRIPTION
The link to the SplObjectStorage class documentation (http://ca2.php.net/manual/en/class.splobjectstorage.php) yields as 404. Replaced it with a working one:
https://www.php.net/manual/en/class.splobjectstorage.php